### PR TITLE
Formats the entire codebase with Fourmolu

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,3 @@
 import Distribution.Simple
+
 main = defaultMain

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,12 +1,12 @@
 module Main (main) where
 
-import Parser(parse)
-import Lexer(alexScanTokens)
-import DgState(DgState, msg, running)
-import qualified DgState
 import qualified Command
+import DgState (DgState, msg, running)
+import qualified DgState
 import qualified Eval
-import System.Random(newStdGen)
+import Lexer (alexScanTokens)
+import Parser (parse)
+import System.Random (newStdGen)
 
 main :: IO ()
 main = do
@@ -25,4 +25,3 @@ run state = do
     let npcResult = Eval.runNpcs playerResult
     putStr ((msg npcResult) ++ "\n")
     if running npcResult then run npcResult else putStr "Game Over\n"
-

--- a/src/Command.hs
+++ b/src/Command.hs
@@ -1,23 +1,24 @@
 module Command (
-    Command(..),
+    Command (..),
     parse,
-    empty
+    empty,
 ) where
 
-import Lib(split)
+import Lib (split)
 
-data Command = Command {
-    name :: String,
-    target :: String,
-    using :: Maybe String
-} deriving Show
+data Command = Command
+    { name :: String
+    , target :: String
+    , using :: Maybe String
+    }
+    deriving (Show)
 
 parse :: String -> Maybe Command
-parse str = parse' (split ' ' str) where
-    parse' (s:t:[]) = Just (Command { name=s, target=t, using=Nothing })
-    parse' (s:t:"using":i:[]) = Just (Command { name=s, target=t, using=(Just i) })
+parse str = parse' (split ' ' str)
+  where
+    parse' (s : t : []) = Just (Command{name = s, target = t, using = Nothing})
+    parse' (s : t : "using" : i : []) = Just (Command{name = s, target = t, using = (Just i)})
     parse' _ = Nothing
 
 empty :: Command
-empty = Command { name="", target="", using=Nothing }
-
+empty = Command{name = "", target = "", using = Nothing}

--- a/src/Entity.hs
+++ b/src/Entity.hs
@@ -1,5 +1,5 @@
 module Entity (
-    Entity(..),
+    Entity (..),
     fromTemplate,
     playerFromTemplate,
     toString,
@@ -7,113 +7,117 @@ module Entity (
     lookupAction,
     itemAttribsToScope,
     statsToScope,
-    getTriggers
+    getTriggers,
 ) where
 
-import qualified EntityTemplate
-import qualified RoomTemplateEntity
-import qualified ItemTemplate
-import qualified Expr
 import qualified Action
-import qualified Trigger
-import qualified Item
 import qualified Command
-import Lib(join, applyTabs)
-import Scope(Scope)
-import qualified Scope as Scope
-import Data.Map(Map)
+import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Set as Set
+import qualified EntityTemplate
+import qualified Expr
+import qualified Item
+import qualified ItemTemplate
+import Lib (applyTabs, join)
+import qualified RoomTemplateEntity
+import Scope (Scope)
+import qualified Scope as Scope
+import qualified Trigger
 
-data Entity = Entity {
-    eType :: EntityTemplate.EntityType,
-    name :: String,
-    args :: Map String Expr.Expr,
-    stats :: Map String Int,
-    alive :: Expr.Expr,
-    actions :: Map String Action.Action,
-    triggers :: Map String Trigger.Trigger,
-    items :: Map String Item.Item,
-    behaviour :: [(Expr.Expr, Command.Command)],
-    defaultBehaviour :: Command.Command
-} deriving Show
+data Entity = Entity
+    { eType :: EntityTemplate.EntityType
+    , name :: String
+    , args :: Map String Expr.Expr
+    , stats :: Map String Int
+    , alive :: Expr.Expr
+    , actions :: Map String Action.Action
+    , triggers :: Map String Trigger.Trigger
+    , items :: Map String Item.Item
+    , behaviour :: [(Expr.Expr, Command.Command)]
+    , defaultBehaviour :: Command.Command
+    }
+    deriving (Show)
 
 lookupAction :: String -> Maybe String -> Maybe Entity -> (Maybe Action.Action, Map String Expr.Expr)
 lookupAction _ _ Nothing = (Nothing, Map.empty)
 lookupAction actionName Nothing (Just e) = (Map.lookup actionName (actions e), Map.empty)
 lookupAction actionName (Just item) (Just e) =
-    case
-        Map.lookup item (items e)
-    of
+    case Map.lookup item (items e) of
         Nothing -> (Nothing, Map.empty)
         (Just i) -> (Map.lookup actionName (Item.actions i), Item.args i)
 
 statsToString :: Map String Int -> [String]
-statsToString m = map statToString (Map.assocs m) where
+statsToString m = map statToString (Map.assocs m)
+  where
     statToString (x, y) = x ++ ": " ++ (show y)
 
 itemsToString :: Int -> Map String Item.Item -> [String]
 itemsToString t m = map (Item.toString t) (Map.elems m)
 
 toString :: Int -> Entity -> String
-toString t e = join
-    "\n"
-    (
-        (applyTabs [(show (eType e))] t)
-        ++ (applyTabs [
-            "Name: " ++ (name e),
-            "Stats"
-        ] (t+1))
-        ++ (applyTabs (statsToString (stats e)) (t+2))
-        ++ (applyTabs ["Actions"] (t+1))
-        ++ (applyTabs (Map.keys (actions e)) (t+2))
-        ++ (applyTabs ["Triggers"] (t+1))
-        ++ (applyTabs (Map.keys (triggers e)) (t+2))
-        ++ (applyTabs ["Items"] (t+1))
-        ++ (itemsToString (t+2) (items e))
-    )
+toString t e =
+    join
+        "\n"
+        ( (applyTabs [(show (eType e))] t)
+            ++ ( applyTabs
+                    [ "Name: " ++ (name e)
+                    , "Stats"
+                    ]
+                    (t + 1)
+               )
+            ++ (applyTabs (statsToString (stats e)) (t + 2))
+            ++ (applyTabs ["Actions"] (t + 1))
+            ++ (applyTabs (Map.keys (actions e)) (t + 2))
+            ++ (applyTabs ["Triggers"] (t + 1))
+            ++ (applyTabs (Map.keys (triggers e)) (t + 2))
+            ++ (applyTabs ["Items"] (t + 1))
+            ++ (itemsToString (t + 2) (items e))
+        )
 
 takeItem :: Item.Item -> Entity -> Entity
-takeItem i e = e { items=(Map.insert (Item.name i) i (items e)) }
+takeItem i e = e{items = (Map.insert (Item.name i) i (items e))}
 
 fromTemplate :: Maybe EntityTemplate.EntityTemplate -> Map String Int -> Map String ItemTemplate.ItemTemplate -> RoomTemplateEntity.RoomTemplateEntity -> Entity.Entity
 fromTemplate Nothing _ _ _ = error "Entity template not found"
-fromTemplate (Just t) statblock itm rte = Entity {
-    eType=(EntityTemplate.eType t),
-    name=(RoomTemplateEntity.name rte),
-    args=(
-        Map.fromList(
-            zip
-                (EntityTemplate.args t)
-                (RoomTemplateEntity.args rte)
-        )
-    ),
-    stats=(statsFromTemplate t statblock),
-    alive=(EntityTemplate.alive t),
-    actions=(EntityTemplate.actions t),
-    triggers=(EntityTemplate.triggers t),
-    behaviour=(EntityTemplate.behaviour t),
-    defaultBehaviour=(EntityTemplate.defaultBehaviour t),
-    items=(
-        Map.union
-            (Item.templateListToInventory (RoomTemplateEntity.items rte) itm)
-            (Item.templateListToInventory (EntityTemplate.items t) itm)
-    )
-}
+fromTemplate (Just t) statblock itm rte =
+    Entity
+        { eType = (EntityTemplate.eType t)
+        , name = (RoomTemplateEntity.name rte)
+        , args =
+            ( Map.fromList
+                ( zip
+                    (EntityTemplate.args t)
+                    (RoomTemplateEntity.args rte)
+                )
+            )
+        , stats = (statsFromTemplate t statblock)
+        , alive = (EntityTemplate.alive t)
+        , actions = (EntityTemplate.actions t)
+        , triggers = (EntityTemplate.triggers t)
+        , behaviour = (EntityTemplate.behaviour t)
+        , defaultBehaviour = (EntityTemplate.defaultBehaviour t)
+        , items =
+            ( Map.union
+                (Item.templateListToInventory (RoomTemplateEntity.items rte) itm)
+                (Item.templateListToInventory (EntityTemplate.items t) itm)
+            )
+        }
 
 playerFromTemplate :: EntityTemplate.EntityTemplate -> Map String Int -> Map String ItemTemplate.ItemTemplate -> Entity.Entity
-playerFromTemplate t statblock itm = Entity {
-    eType=(EntityTemplate.eType t),
-    name="player",
-    args=Map.empty,
-    stats=(statsFromTemplate t statblock),
-    alive=(EntityTemplate.alive t),
-    actions=(EntityTemplate.actions t),
-    triggers=(EntityTemplate.triggers t),
-    behaviour=[],
-    defaultBehaviour=Command.empty,
-    items=Item.templateListToInventory (EntityTemplate.items t) itm
-}
+playerFromTemplate t statblock itm =
+    Entity
+        { eType = (EntityTemplate.eType t)
+        , name = "player"
+        , args = Map.empty
+        , stats = (statsFromTemplate t statblock)
+        , alive = (EntityTemplate.alive t)
+        , actions = (EntityTemplate.actions t)
+        , triggers = (EntityTemplate.triggers t)
+        , behaviour = []
+        , defaultBehaviour = Command.empty
+        , items = Item.templateListToInventory (EntityTemplate.items t) itm
+        }
 
 statsFromTemplate :: EntityTemplate.EntityTemplate -> Map String Int -> Map String Int
 statsFromTemplate t statblock =
@@ -131,11 +135,9 @@ statsToScope e = Scope.fromIntArgs (stats e)
 getTriggers :: Entity -> [Trigger.Trigger]
 getTriggers e =
     (Map.elems (triggers e))
-    ++ (
-        foldl
-            (++)
-            []
-            (map (Map.elems . Item.triggers) (Map.elems (items e))
-        )
-    )
-
+        ++ ( foldl
+                (++)
+                []
+                ( map (Map.elems . Item.triggers) (Map.elems (items e))
+                )
+           )

--- a/src/Item.hs
+++ b/src/Item.hs
@@ -1,67 +1,68 @@
 module Item (
-    Item(..),
+    Item (..),
     fromTemplate,
     toString,
-    templateListToInventory
+    templateListToInventory,
 ) where
 
-import qualified Expr
 import qualified Action
-import qualified Trigger
-import qualified ItemTemplate
-import qualified RoomTemplateItem
-import Data.Set(Set)
-import qualified Data.Set as Set
-import Data.Map(Map)
+import Data.Map (Map)
 import qualified Data.Map as Map
-import Lib(join, applyTabs, listToMap)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import qualified Expr
+import qualified ItemTemplate
+import Lib (applyTabs, join, listToMap)
+import qualified RoomTemplateItem
+import qualified Trigger
 
-data Item = Item {
-    name :: String,
-    attribs :: Set String,
-    args :: Map String Expr.Expr,
-    actions :: Map String Action.Action,
-    triggers :: Map String Trigger.Trigger
-} deriving Show
+data Item = Item
+    { name :: String
+    , attribs :: Set String
+    , args :: Map String Expr.Expr
+    , actions :: Map String Action.Action
+    , triggers :: Map String Trigger.Trigger
+    }
+    deriving (Show)
 
 toString :: Int -> Item -> String
-toString t i = join
-    "\n"
-    (
-        (applyTabs [name i] t)
-        ++ (applyTabs ["Attributes"] (t+1))
-        ++ (applyTabs (Set.elems (attribs i)) (t+2))
-        ++ (applyTabs ["Actions"] (t+1))
-        ++ (applyTabs (Map.keys (actions i)) (t+2))
-        ++ (applyTabs ["Triggers"] (t+1))
-        ++ (applyTabs (Map.keys (triggers i)) (t+2))
-    )
+toString t i =
+    join
+        "\n"
+        ( (applyTabs [name i] t)
+            ++ (applyTabs ["Attributes"] (t + 1))
+            ++ (applyTabs (Set.elems (attribs i)) (t + 2))
+            ++ (applyTabs ["Actions"] (t + 1))
+            ++ (applyTabs (Map.keys (actions i)) (t + 2))
+            ++ (applyTabs ["Triggers"] (t + 1))
+            ++ (applyTabs (Map.keys (triggers i)) (t + 2))
+        )
 
 fromTemplate :: Maybe ItemTemplate.ItemTemplate -> RoomTemplateItem.RoomTemplateItem -> Item
 fromTemplate Nothing _ = error "Item template not found"
-fromTemplate (Just t) rti = Item {
-    name=RoomTemplateItem.name rti,
-    attribs=(
-        Set.union
-            (Set.fromList (ItemTemplate.attribs t))
-            (Set.fromList (RoomTemplateItem.attribs rti))
-    ),
-    args=Map.fromList (zip (ItemTemplate.args t) (RoomTemplateItem.args rti)),
-    actions=ItemTemplate.actions t,
-    triggers=ItemTemplate.triggers t
-}
+fromTemplate (Just t) rti =
+    Item
+        { name = RoomTemplateItem.name rti
+        , attribs =
+            ( Set.union
+                (Set.fromList (ItemTemplate.attribs t))
+                (Set.fromList (RoomTemplateItem.attribs rti))
+            )
+        , args = Map.fromList (zip (ItemTemplate.args t) (RoomTemplateItem.args rti))
+        , actions = ItemTemplate.actions t
+        , triggers = ItemTemplate.triggers t
+        }
 
 templateListToInventory :: [RoomTemplateItem.RoomTemplateItem] -> Map String ItemTemplate.ItemTemplate -> Map String Item
-templateListToInventory rtis itm = listToMap
-    (
-        map
-            (
-                \rti -> fromTemplate
+templateListToInventory rtis itm =
+    listToMap
+        ( map
+            ( \rti ->
+                fromTemplate
                     (Map.lookup (RoomTemplateItem.template rti) itm)
                     rti
             )
             rtis
-    )
-    name
-    id
-
+        )
+        name
+        id

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -5,50 +5,50 @@ module Lib (
     applyTab,
     applyTabs,
     split,
-    popMap
+    popMap,
 ) where
 
-import Data.Map(Map)
+import Data.Map (Map)
 import qualified Data.Map as Map
 
 rev :: [a] -> [a]
 rev xs = foldl rev' [] xs
-    where
-        rev' :: [a] -> a -> [a]
-        rev' acc x = x:acc
+  where
+    rev' :: [a] -> a -> [a]
+    rev' acc x = x : acc
 
-listToMap :: Ord b => [a] -> (a -> b) -> (a -> c) -> Map b c
+listToMap :: (Ord b) => [a] -> (a -> b) -> (a -> c) -> Map b c
 listToMap xs key val = foldr (\x acc -> (Map.insert (key x) (val x) acc)) Map.empty xs
 
-popMap :: Ord a => a -> Map a b -> (Maybe b, Map a b)
+popMap :: (Ord a) => a -> Map a b -> (Maybe b, Map a b)
 popMap key m = (Map.lookup key m, Map.filterWithKey (\k _ -> k /= key) m)
 
 tab :: Int -> String
 tab n
     | n <= 0 = []
-    | otherwise = ' ':(tab (n-1))
+    | otherwise = ' ' : (tab (n - 1))
 
-applyTabs :: [String] -> Int  -> [String]
+applyTabs :: [String] -> Int -> [String]
 applyTabs sl t = map (\s -> applyTab s t) sl
 
-applyTab :: String -> Int  -> String
+applyTab :: String -> Int -> String
 applyTab s t = (tab t) ++ s
 
 join :: String -> [String] -> String
 join _ [] = ""
-join _ (x:[]) = x
-join i (x:xs) = x ++ i ++ (join i xs)
+join _ (x : []) = x
+join i (x : xs) = x ++ i ++ (join i xs)
 
 splitTake :: Char -> String -> (String, String)
-splitTake char str = splitTake' char str [] where
+splitTake char str = splitTake' char str []
+  where
     splitTake' _ [] acc = (acc, [])
-    splitTake' c (x:xs) acc = if x == c then (acc, xs) else splitTake' c xs (x:acc)
+    splitTake' c (x : xs) acc = if x == c then (acc, xs) else splitTake' c xs (x : acc)
 
 split :: Char -> String -> [String]
 split _ [] = []
 split c s =
     let
         (part, rest) = splitTake c s
-    in
-        if part == "" then split c rest else (rev part):(split c rest)
-
+     in
+        if part == "" then split c rest else (rev part) : (split c rest)

--- a/src/Room.hs
+++ b/src/Room.hs
@@ -1,5 +1,5 @@
-module Room(
-    Room(..),
+module Room (
+    Room (..),
     fromTemplate,
     toString,
     takeItem,
@@ -7,73 +7,75 @@ module Room(
     getDoor,
     getEntityNames,
     getEntities,
-    killEntity
+    killEntity,
 ) where
 
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Door (Door)
+import qualified Door
 import qualified Entity
-import qualified Item
 import qualified EntityTemplate
+import qualified Item
 import qualified ItemTemplate
+import Lib (applyTabs, join, listToMap, popMap)
 import qualified RoomTemplate
 import qualified RoomTemplateEntity
-import Door(Door)
-import qualified Door
-import Lib(listToMap, join, applyTabs, popMap)
-import Data.Map(Map)
-import qualified Data.Map as Map
 
-data Room = Room {
-    name :: String,
-    entities :: Map String Entity.Entity,
-    items :: Map String Item.Item,
-    doors :: Map String Door
-} deriving Show
+data Room = Room
+    { name :: String
+    , entities :: Map String Entity.Entity
+    , items :: Map String Item.Item
+    , doors :: Map String Door
+    }
+    deriving (Show)
 
 lookupEntity :: String -> Room -> Maybe Entity.Entity
 lookupEntity entityName r = Map.lookup entityName (entities r)
 
 toString :: Int -> Room -> String
-toString t r = join
-    "\n"
-    (
-        (applyTabs ["Room"] t)
-        ++ (applyTabs ["Name: " ++ (name r)] (t+1))
-        ++ (applyTabs ["Entities"] (t+1))
-        ++ (map (Entity.toString (t+2)) (Map.elems (entities r)))
-        ++ (applyTabs ["Items"] (t+1))
-        ++ (map (Item.toString (t+2)) (Map.elems (items r)))
-        ++ (map (Door.toString (t+1)) (Map.elems (doors r)))
-    )
+toString t r =
+    join
+        "\n"
+        ( (applyTabs ["Room"] t)
+            ++ (applyTabs ["Name: " ++ (name r)] (t + 1))
+            ++ (applyTabs ["Entities"] (t + 1))
+            ++ (map (Entity.toString (t + 2)) (Map.elems (entities r)))
+            ++ (applyTabs ["Items"] (t + 1))
+            ++ (map (Item.toString (t + 2)) (Map.elems (items r)))
+            ++ (map (Door.toString (t + 1)) (Map.elems (doors r)))
+        )
 
 fromTemplate :: Map String EntityTemplate.EntityTemplate -> Map String ItemTemplate.ItemTemplate -> Map String Int -> RoomTemplate.RoomTemplate -> Room
-fromTemplate etm itm sb rt = Room {
-    name=RoomTemplate.name rt,
-    entities=listToMap
-        (
-            map
-                (
-                    \rte -> Entity.fromTemplate
-                        (Map.lookup (RoomTemplateEntity.template rte) etm)
-                        sb
-                        itm
-                        rte
+fromTemplate etm itm sb rt =
+    Room
+        { name = RoomTemplate.name rt
+        , entities =
+            listToMap
+                ( map
+                    ( \rte ->
+                        Entity.fromTemplate
+                            (Map.lookup (RoomTemplateEntity.template rte) etm)
+                            sb
+                            itm
+                            rte
+                    )
+                    (RoomTemplate.entities rt)
                 )
-                (RoomTemplate.entities rt)
-        )
-        Entity.name
-        id,
-    items=Item.templateListToInventory (RoomTemplate.items rt) itm,
-    doors=(listToMap (RoomTemplate.doors rt) Door.name id)
-}
+                Entity.name
+                id
+        , items = Item.templateListToInventory (RoomTemplate.items rt) itm
+        , doors = (listToMap (RoomTemplate.doors rt) Door.name id)
+        }
 
 updateItems :: Map String Item.Item -> Room -> Room
-updateItems i r = r { items=i }
+updateItems i r = r{items = i}
 
 takeItem :: String -> Room -> (Maybe Item.Item, Room)
 takeItem s r =
     let
         (item, rest) = Lib.popMap s (items r)
-    in
+     in
         (item, updateItems rest r)
 
 getDoor :: String -> Room -> Maybe Door
@@ -89,11 +91,11 @@ killEntity :: String -> Room -> Room
 killEntity entityName r =
     let
         entity = Map.lookup entityName (entities r)
-    in
+     in
         case entity of
             Nothing -> r
-            (Just e) -> r {
-                entities=Map.delete entityName (entities r),
-                items=Map.union (Entity.items e) (items r)
-            }
-
+            (Just e) ->
+                r
+                    { entities = Map.delete entityName (entities r)
+                    , items = Map.union (Entity.items e) (items r)
+                    }

--- a/src/Scope.hs
+++ b/src/Scope.hs
@@ -10,16 +10,16 @@ module Scope (
     singletonWithDefault,
     fromArgs,
     fromIntArgs,
-    emptyWithFalseDefault
+    emptyWithFalseDefault,
 ) where
 
-import Prelude hiding (lookup)
-import Data.Map(Map)
+import Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Expr
+import Prelude hiding (lookup)
 
-data Cactus = Cactus (Map String Expr.Expr) (Maybe Cactus) deriving Show
-data Scope = Scope Cactus (Maybe Expr.Expr) deriving Show
+data Cactus = Cactus (Map String Expr.Expr) (Maybe Cactus) deriving (Show)
+data Scope = Scope Cactus (Maybe Expr.Expr) deriving (Show)
 
 empty :: Scope
 empty = Scope (Cactus Map.empty Nothing) Nothing
@@ -82,4 +82,3 @@ lookup (Scope c Nothing) var = case (lookup' c var) of
 lookup (Scope c (Just d)) var = case (lookup' c var) of
     Nothing -> d
     (Just x) -> x
-

--- a/src/nodes/Action.hs
+++ b/src/nodes/Action.hs
@@ -1,9 +1,9 @@
-module Action(Action(..)) where
+module Action (Action (..)) where
 
-import Stmt(Stmt)
+import Stmt (Stmt)
 
-data Action = Action {
-    name :: String,
-    stmts :: [Stmt]
-} deriving Show
-
+data Action = Action
+    { name :: String
+    , stmts :: [Stmt]
+    }
+    deriving (Show)

--- a/src/nodes/Assign.hs
+++ b/src/nodes/Assign.hs
@@ -1,9 +1,9 @@
-module Assign(Assign(..)) where
+module Assign (Assign (..)) where
 
-import Expr(Expr)
+import Expr (Expr)
 
-data Assign = Assign {
-    var :: String,
-    val :: Expr
-} deriving Show
-
+data Assign = Assign
+    { var :: String
+    , val :: Expr
+    }
+    deriving (Show)

--- a/src/nodes/AssignStat.hs
+++ b/src/nodes/AssignStat.hs
@@ -1,10 +1,10 @@
-module AssignStat(AssignStat(..)) where
+module AssignStat (AssignStat (..)) where
 
-import Stat(Stat)
-import Expr(Expr)
+import Expr (Expr)
+import Stat (Stat)
 
-data AssignStat = AssignStat {
-    stat :: Stat,
-    val :: Expr
-} deriving Show
-
+data AssignStat = AssignStat
+    { stat :: Stat
+    , val :: Expr
+    }
+    deriving (Show)

--- a/src/nodes/Declare.hs
+++ b/src/nodes/Declare.hs
@@ -1,9 +1,9 @@
-module Declare(Declare(..)) where
+module Declare (Declare (..)) where
 
-import Expr(Expr)
+import Expr (Expr)
 
-data Declare = Declare {
-    var :: String,
-    val :: Expr
-} deriving Show
-
+data Declare = Declare
+    { var :: String
+    , val :: Expr
+    }
+    deriving (Show)

--- a/src/nodes/Dice.hs
+++ b/src/nodes/Dice.hs
@@ -1,30 +1,31 @@
-module Dice(
-    Dice(..),
+module Dice (
+    Dice (..),
     fromStr,
-    roll
+    roll,
 ) where
 
-import System.Random(StdGen, randomR)
+import System.Random (StdGen, randomR)
 
-data Dice = Dice {
-    count :: Int,
-    size :: Int
-} deriving Show
+data Dice = Dice
+    { count :: Int
+    , size :: Int
+    }
+    deriving (Show)
 
 fromStr :: String -> Dice
-fromStr s = Dice {
-    count=(read (takeWhile (/='d') s)),
-    size=(read (tail (dropWhile (/='d') s)))
-}
+fromStr s =
+    Dice
+        { count = (read (takeWhile (/= 'd') s))
+        , size = (read (tail (dropWhile (/= 'd') s)))
+        }
 
 roll :: StdGen -> Dice -> (Int, StdGen)
 roll gen d
     | (count d) <= 0 = (0, gen)
     | (size d) <= 0 = (0, gen)
     | otherwise = roll' (count d) (size d) gen 0
-    where
-        roll' 0 _ rng acc = (acc, rng)
-        roll' c s rng acc =
-            let (val, newRng) = randomR (1, s) rng in
-                roll' (c - 1) s newRng (acc + val)
-
+  where
+    roll' 0 _ rng acc = (acc, rng)
+    roll' c s rng acc =
+        let (val, newRng) = randomR (1, s) rng
+         in roll' (c - 1) s newRng (acc + val)

--- a/src/nodes/Door.hs
+++ b/src/nodes/Door.hs
@@ -1,14 +1,14 @@
-module Door(Door(..), toString) where
+module Door (Door (..), toString) where
 
-import Expr(Expr)
-import Lib(join, applyTab)
+import Expr (Expr)
+import Lib (applyTab, join)
 
-data Door = Door {
-    name :: String,
-    to :: String,
-    req :: Expr
-} deriving Show
+data Door = Door
+    { name :: String
+    , to :: String
+    , req :: Expr
+    }
+    deriving (Show)
 
 toString :: Int -> Door -> String
 toString tabs door = applyTab (join " " ["Door", (name door), "to", (to door)]) tabs
-

--- a/src/nodes/Dungeon.hs
+++ b/src/nodes/Dungeon.hs
@@ -1,18 +1,18 @@
-module Dungeon(
-    Dungeon (..)
+module Dungeon (
+    Dungeon (..),
 ) where
 
-import Data.Map(Map)
-import EntityTemplate(EntityTemplate)
-import ItemTemplate(ItemTemplate)
-import RoomTemplate(RoomTemplate)
+import Data.Map (Map)
+import EntityTemplate (EntityTemplate)
+import ItemTemplate (ItemTemplate)
+import RoomTemplate (RoomTemplate)
 
-data Dungeon = Dungeon {
-    name :: String,
-    statblock :: Map String Int,
-    playerTemplate :: EntityTemplate,
-    enemyTemplates :: Map String EntityTemplate,
-    itemTemplates :: Map String ItemTemplate,
-    roomTemplates :: [RoomTemplate]
-} deriving Show
-
+data Dungeon = Dungeon
+    { name :: String
+    , statblock :: Map String Int
+    , playerTemplate :: EntityTemplate
+    , enemyTemplates :: Map String EntityTemplate
+    , itemTemplates :: Map String ItemTemplate
+    , roomTemplates :: [RoomTemplate]
+    }
+    deriving (Show)

--- a/src/nodes/EntityTemplate.hs
+++ b/src/nodes/EntityTemplate.hs
@@ -1,23 +1,24 @@
-module EntityTemplate(EntityTemplate(..), EntityType(..)) where
+module EntityTemplate (EntityTemplate (..), EntityType (..)) where
 
-import Data.Map(Map)
-import Expr(Expr)
-import Action(Action)
-import Trigger(Trigger)
-import RoomTemplateItem(RoomTemplateItem)
-import Command(Command)
+import Action (Action)
+import Command (Command)
+import Data.Map (Map)
+import Expr (Expr)
+import RoomTemplateItem (RoomTemplateItem)
+import Trigger (Trigger)
 
-data EntityType = Player | Enemy deriving Show
+data EntityType = Player | Enemy deriving (Show)
 
-data EntityTemplate = EntityTemplate {
-    eType :: EntityType,
-    name :: String,
-    args :: [String],
-    stats :: Map String Int,
-    alive :: Expr,
-    actions :: Map String Action,
-    triggers :: Map String Trigger,
-    behaviour :: [(Expr, Command)],
-    defaultBehaviour :: Command,
-    items :: [RoomTemplateItem]
-} deriving Show
+data EntityTemplate = EntityTemplate
+    { eType :: EntityType
+    , name :: String
+    , args :: [String]
+    , stats :: Map String Int
+    , alive :: Expr
+    , actions :: Map String Action
+    , triggers :: Map String Trigger
+    , behaviour :: [(Expr, Command)]
+    , defaultBehaviour :: Command
+    , items :: [RoomTemplateItem]
+    }
+    deriving (Show)

--- a/src/nodes/Expr.hs
+++ b/src/nodes/Expr.hs
@@ -1,7 +1,7 @@
-module Expr(Expr(..), BinOp(..), UnOp(..)) where
+module Expr (Expr (..), BinOp (..), UnOp (..)) where
 
-import Dice(Dice)
-import Stat(Stat)
+import Dice (Dice)
+import Stat (Stat)
 
 data BinOp
     = Add
@@ -14,11 +14,13 @@ data BinOp
     | Mul
     | Div
     | Mod
-    | And deriving Show
+    | And
+    deriving (Show)
 
 data UnOp
     = Neg
-    | Not deriving Show
+    | Not
+    deriving (Show)
 
 data Expr
     = BinOpExpr BinOp Expr Expr
@@ -26,5 +28,5 @@ data Expr
     | IntExpr Int
     | DiceExpr Dice
     | VarExpr String
-    | StatExpr Stat deriving Show
-
+    | StatExpr Stat
+    deriving (Show)

--- a/src/nodes/Func.hs
+++ b/src/nodes/Func.hs
@@ -1,9 +1,9 @@
-module Func(Func(..)) where
+module Func (Func (..)) where
 
-import Expr(Expr)
+import Expr (Expr)
 
-data Func = Func {
-    name :: String,
-    args :: [Expr]
-} deriving Show
-
+data Func = Func
+    { name :: String
+    , args :: [Expr]
+    }
+    deriving (Show)

--- a/src/nodes/If.hs
+++ b/src/nodes/If.hs
@@ -1,4 +1,3 @@
-module If(If(..)) where
+module If (If (..)) where
 
 import InternalStmt
-

--- a/src/nodes/InternalStmt.hs
+++ b/src/nodes/InternalStmt.hs
@@ -1,19 +1,21 @@
-module InternalStmt(Stmt(..), If(..), While(..)) where
+module InternalStmt (Stmt (..), If (..), While (..)) where
 
-import Declare(Declare)
-import Assign(Assign)
-import AssignStat(AssignStat)
-import Func(Func)
-import Expr(Expr)
+import Assign (Assign)
+import AssignStat (AssignStat)
+import Declare (Declare)
+import Expr (Expr)
+import Func (Func)
 
-data If = If {
-    conds :: [(Expr, [Stmt])]
-} deriving Show
+data If = If
+    { conds :: [(Expr, [Stmt])]
+    }
+    deriving (Show)
 
-data While = While {
-    cond :: Expr,
-    stmts :: [Stmt]
-} deriving Show
+data While = While
+    { cond :: Expr
+    , stmts :: [Stmt]
+    }
+    deriving (Show)
 
 data Stmt
     = DeclareStmt Declare
@@ -21,5 +23,5 @@ data Stmt
     | AssignStatStmt AssignStat
     | FuncStmt Func
     | WhileStmt While
-    | IfStmt If deriving Show
-
+    | IfStmt If
+    deriving (Show)

--- a/src/nodes/ItemTemplate.hs
+++ b/src/nodes/ItemTemplate.hs
@@ -1,14 +1,14 @@
-module ItemTemplate(ItemTemplate(..)) where
+module ItemTemplate (ItemTemplate (..)) where
 
-import Data.Map(Map)
-import Action(Action)
-import Trigger(Trigger)
+import Action (Action)
+import Data.Map (Map)
+import Trigger (Trigger)
 
-data ItemTemplate = ItemTemplate {
-    name :: String,
-    attribs :: [String],
-    args :: [String],
-    actions :: Map String Action,
-    triggers :: Map String Trigger
-} deriving Show
-
+data ItemTemplate = ItemTemplate
+    { name :: String
+    , attribs :: [String]
+    , args :: [String]
+    , actions :: Map String Action
+    , triggers :: Map String Trigger
+    }
+    deriving (Show)

--- a/src/nodes/RoomTemplate.hs
+++ b/src/nodes/RoomTemplate.hs
@@ -1,13 +1,13 @@
-module RoomTemplate(RoomTemplate(..)) where
+module RoomTemplate (RoomTemplate (..)) where
 
-import RoomTemplateEntity(RoomTemplateEntity)
-import RoomTemplateItem(RoomTemplateItem)
-import Door(Door)
+import Door (Door)
+import RoomTemplateEntity (RoomTemplateEntity)
+import RoomTemplateItem (RoomTemplateItem)
 
-data RoomTemplate = RoomTemplate {
-    name :: String,
-    entities :: [RoomTemplateEntity],
-    items :: [RoomTemplateItem],
-    doors :: [Door]
-} deriving Show
-
+data RoomTemplate = RoomTemplate
+    { name :: String
+    , entities :: [RoomTemplateEntity]
+    , items :: [RoomTemplateItem]
+    , doors :: [Door]
+    }
+    deriving (Show)

--- a/src/nodes/RoomTemplateEntity.hs
+++ b/src/nodes/RoomTemplateEntity.hs
@@ -1,13 +1,12 @@
-module RoomTemplateEntity(RoomTemplateEntity(..)) where
+module RoomTemplateEntity (RoomTemplateEntity (..)) where
 
-import Expr(Expr)
-import RoomTemplateItem(RoomTemplateItem)
+import Expr (Expr)
+import RoomTemplateItem (RoomTemplateItem)
 
-data RoomTemplateEntity = RoomTemplateEntity {
-    name :: String,
-    template :: String,
-    args :: [Expr],
-    items :: [RoomTemplateItem]
-
-} deriving Show
-
+data RoomTemplateEntity = RoomTemplateEntity
+    { name :: String
+    , template :: String
+    , args :: [Expr]
+    , items :: [RoomTemplateItem]
+    }
+    deriving (Show)

--- a/src/nodes/RoomTemplateItem.hs
+++ b/src/nodes/RoomTemplateItem.hs
@@ -1,11 +1,11 @@
-module RoomTemplateItem(RoomTemplateItem(..)) where
+module RoomTemplateItem (RoomTemplateItem (..)) where
 
-import Expr(Expr)
+import Expr (Expr)
 
-data RoomTemplateItem = RoomTemplateItem {
-    name :: String,
-    template :: String,
-    attribs :: [String],
-    args :: [Expr]
-} deriving Show
-
+data RoomTemplateItem = RoomTemplateItem
+    { name :: String
+    , template :: String
+    , attribs :: [String]
+    , args :: [Expr]
+    }
+    deriving (Show)

--- a/src/nodes/Stat.hs
+++ b/src/nodes/Stat.hs
@@ -1,7 +1,7 @@
-module Stat(Stat(..)) where 
+module Stat (Stat (..)) where
 
-data Stat = Stat {
-    owner :: String,
-    name :: String
-} deriving Show
-
+data Stat = Stat
+    { owner :: String
+    , name :: String
+    }
+    deriving (Show)

--- a/src/nodes/Stmt.hs
+++ b/src/nodes/Stmt.hs
@@ -1,4 +1,3 @@
-module Stmt(Stmt(..)) where
+module Stmt (Stmt (..)) where
 
 import InternalStmt
-

--- a/src/nodes/Trigger.hs
+++ b/src/nodes/Trigger.hs
@@ -1,11 +1,11 @@
-module Trigger(Trigger(..)) where
+module Trigger (Trigger (..)) where
 
-import Expr(Expr)
-import Stmt(Stmt)
+import Expr (Expr)
+import Stmt (Stmt)
 
-data Trigger = Trigger {
-    name :: String,
-    on :: Expr,
-    stmts :: [Stmt]
-} deriving Show
-
+data Trigger = Trigger
+    { name :: String
+    , on :: Expr
+    , stmts :: [Stmt]
+    }
+    deriving (Show)

--- a/src/nodes/While.hs
+++ b/src/nodes/While.hs
@@ -1,4 +1,3 @@
-module While(While(..)) where
+module While (While (..)) where
 
 import InternalStmt
-


### PR DESCRIPTION
Feel free to ignore this but I compared a few different code formatters and it looks like [Fourmolu](https://hackage.haskell.org/package/fourmolu) gets the closest to the kind of style that you were going for.

Steps I took:
```
stack install fourmolu
~/.local/bin/fourmolu -i **/*.hs
```

To prevent this massive commit from cluttering the output from `git blame`, I've also pushed a file that can be used to instruct git to ignore this commit when ascribing authorship to each code line.

Compare
```
$ git --no-pager blame src/nodes/Stmt.hs
31c04a8d (Bruno Lange 2024-04-30 13:09:29 +0200 1) module Stmt (Stmt (..)) where
7728e638 (lifesci     2024-01-05 19:15:58 -0800 2) 
17e95302 (lifesci     2024-01-06 14:14:52 -0800 3) import InternalStmt
```

with:
```
git --no-pager blame src/nodes/Stmt.hs --ignore-revs-file .git-blame-ignore-revs
17e95302 (lifesci 2024-01-06 14:14:52 -0800 1) module Stmt (Stmt (..)) where
7728e638 (lifesci 2024-01-05 19:15:58 -0800 2) 
17e95302 (lifesci 2024-01-06 14:14:52 -0800 3) import InternalStmt
```

Git can be locally configured to always ignore the commits in this file when generating blame output:

```
$ git config blame.ignoreRevsFile .git-blame-ignore-revs
$ git --no-pager blame src/nodes/Stmt.hs                               
17e95302 (lifesci 2024-01-06 14:14:52 -0800 1) module Stmt (Stmt (..)) where
7728e638 (lifesci 2024-01-05 19:15:58 -0800 2) 
17e95302 (lifesci 2024-01-06 14:14:52 -0800 3) import InternalStmt
```

I configured my IDE to automatically apply Fourmolu on save. If you're onboard with a standardized formatter I can look into setting up a [github action](https://github.com/haskell-actions/run-fourmolu) to ensure it.
